### PR TITLE
Remove server and local filesystem paths from public docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,9 @@ If any of these need re-checking, the README documents how to re-derive them fro
 
 **`docs/data/wwscan_summary.json` is the single source of truth for the headline**, consumed by both the dashboard JS and the server email script. Don't reimplement the tertile cutoffs or the slope test in JavaScript or on the server.
 
-**Email lives outside this repo.** `/srv/shiny-server/framingham_covid/run_wwscan_email.R` on Sharon's Linux server reads the published CSV and summary from GitHub raw. Local copy: `D:\Sharon\Docs\R\shiny-server\framingham_covid`. That local copy may lag the server — diff before deploying, and don't edit the existing MWRA modules there.
+**`docs/data/wwscan_summary.json` and `data/processed/wwscan_covid.csv` are a published interface**, not private dashboard files — they are fetched over HTTP from `raw.githubusercontent.com` by a consumer outside this repo. Renaming their fields or paths breaks that consumer silently, and nothing in this repo's test suite will catch it. Treat a change to either as a breaking change.
+
+**This file is public.** It is committed to a public GitHub repo, so keep deployment specifics, server paths, hostnames, and anything else environment-specific out of it. Those live in `.claude/DEPLOYMENT.md`, which is gitignored — read that file when working on anything deployment-related.
 
 ## Testing conventions
 

--- a/README.md
+++ b/README.md
@@ -293,9 +293,12 @@ biobot_mwra/
 
 ## Email notifications
 
-The emails that go out when there's new data are sent by a separate R script on
-my Linux server (`/srv/shiny-server/framingham_covid`), not from this repo. That
-script reads `wwscan_summary.json` and `wwscan_covid.csv` from GitHub rather
-than fetching or recalculating anything, so the trend math lives in one place.
-It sends at most weekly, but breaks that cadence immediately when the level or
-trend direction changes.
+I send myself an email when there's new data. That runs outside this repo and
+just reads the published files below, so nothing here needs to know about it.
+
+If you're reusing this code, treat these two as a **stable interface** rather
+than internal dashboard files — anything consuming them over HTTP will break
+silently if their fields are renamed, and this repo's tests won't catch it:
+
+- `docs/data/wwscan_summary.json` — headline, level, trend, change sentence
+- `data/processed/wwscan_covid.csv` — the full series


### PR DESCRIPTION
This is a public repo. CLAUDE.md and README.md both named the Linux
server directory the email script runs from, plus a local Windows path.
No credentials, but deployment layout does not belong in public docs.

Deployment specifics now live in .claude/DEPLOYMENT.md, which is
gitignored. CLAUDE.md says so explicitly, and now states that it is
itself public so the same mistake is less likely next time.

The published-interface note is kept, reworded so it is useful to anyone
reusing the repo without describing my setup.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
