### PR TITLE
Fix false-alarm failures on MWRA Biobot check; run once daily

### DIFF
--- a/.github/workflows/check-data.yml
+++ b/.github/workflows/check-data.yml
@@ -1,9 +1,11 @@
 name: Check MWRA Biobot Data
 
 on:
-  # Run twice daily at 13:48 and 21:48 UTC
+  # Run once daily at 13:48 UTC. MWRA publishes weekly at most even when
+  # healthy, so once a day catches a resume promptly without doubling the noise
+  # and CI minutes.
   schedule:
-    - cron: '48 13,21 * * *'
+    - cron: '48 13 * * *'
 
   # Allow manual trigger
   workflow_dispatch:
@@ -48,16 +50,28 @@ jobs:
         id: check
         run: Rscript run_monitor.R
 
+      # Commit on a real data update (data + plots + docs + state), and also on
+      # a clean no-new-data run (state only) so last_successful_fetch persists
+      # across fresh CI checkouts -- without that, the bot-challenge alarm keyed
+      # off it in run_monitor.R would reset to stale every run and false-fail.
       - name: Commit and push changes
-        if: steps.check.outputs.data_updated == 'true'
+        if: steps.check.outputs.data_updated == 'true' || steps.check.outputs.fetch_ok == 'true'
         run: |
           # Running as root inside the container, the checkout is owned by a
           # different uid, so mark the workspace safe before touching git.
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git add data/ output/ state/ docs/
-          git diff --staged --quiet || git commit -m "Update MWRA Biobot data (${{ steps.check.outputs.sample_date }})"
+          if [ "${{ steps.check.outputs.data_updated }}" = "true" ]; then
+            git add data/ output/ state/ docs/
+            msg="Update MWRA Biobot data (${{ steps.check.outputs.sample_date }})"
+          else
+            # No new data, but the page loaded cleanly -- persist just the fetch
+            # marker so a later challenged run stays a quiet no-op.
+            git add state/
+            msg="Record successful MWRA fetch"
+          fi
+          git diff --staged --quiet || git commit -m "$msg"
           # check-wwscan.yml also commits to main; rebase rather than fail if
           # it landed something between checkout and push.
           git pull --rebase origin main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this is
 
-An R pipeline that scrapes MWRA's Biobot COVID wastewater PDF, extracts the data tables, writes CSVs, generates static plots, and updates a JS dashboard published to GitHub Pages. Runs twice daily via GitHub Actions. State (the last known sample date) is committed to the repo, so runs are stateless between CI invocations.
+An R pipeline that scrapes MWRA's Biobot COVID wastewater PDF, extracts the data tables, writes CSVs, generates static plots, and updates a JS dashboard published to GitHub Pages. Runs once daily via GitHub Actions. State (the last known sample date and the last time the bot wall let us through) is committed to the repo, so runs are stateless between CI invocations.
 
 Since August 2026 there is a **second, parallel pipeline** (`run_wwscan.R` + `R/05_wwscan.R`) reading WastewaterSCAN's feed for the same Deer Island sewershed. It exists because MWRA's Biobot publishing stalled for 19 days in July 2026. The two pipelines share only `R/utils.R`; they have separate state files, CSVs, workflows, and charts.
 
@@ -65,7 +65,7 @@ There is no build step and no linter configured.
 
 **The MWRA bot wall is the central design constraint.** MWRA sits behind an Imperva/Incapsula challenge that intermittently serves an interstitial page instead of real content — to both the page scrape and the PDF download. `impersonate_fetch()` shells out to `curl-impersonate` (patched curl with a Chrome TLS fingerprint) rather than using httr2/libcurl, because plain libcurl traffic gets fingerprinted and blocked. `is_bot_challenge()` detects the interstitial by signature strings.
 
-A challenge is treated as a **transient no-op** — clean exit, no alarm — *unless* the newest processed data is older than `MAX_STALE_DAYS` (14, in `run_monitor.R`), in which case the run fails loudly. See `handle_challenge()` in `run_monitor.R` and `data_staleness_days()` in `R/utils.R`. Any change to fetch or retry logic must preserve this distinction between "challenged, retry next run" and "genuinely broken, wake a human." `last_sample_date` advances only on a fully successful run, which is what makes the staleness check survive fresh CI checkouts — no per-run counter would.
+A challenge is treated as a **transient no-op** — clean exit, no alarm — *unless* the bypass hasn't gotten a clean page load through the bot wall in `MAX_STALE_DAYS` (14, in `run_monitor.R`), in which case the run fails loudly. See `handle_challenge()` in `run_monitor.R` and `fetch_staleness_days()` in `R/utils.R`. Crucially, this is keyed off `last_successful_fetch` (when the bypass last worked), **not** off how old the *data* is: MWRA routinely pauses publishing for weeks with a healthy bypass — that pause is a separate, benign signal reported once via the `stale-data` issue (driven by `data_staleness_days()` / `last_sample_date`), and it must not turn every challenged run red. Any change to fetch or retry logic must preserve this three-way distinction: "challenged but bypass healthy, retry next run" vs "MWRA paused publishing, file one issue" vs "bypass genuinely shut out, wake a human." `last_successful_fetch` advances on any clean page load (new data or not) and `last_sample_date` only on a fully successful data run; both survive fresh CI checkouts because `check-data.yml` commits `state/` on clean runs, not only on data updates — a per-run counter would not.
 
 **`impersonate_fetch()` is the only network entry point** in the codebase. Every network-touching test stubs it. Keep it that way; adding a second fetch path would silently escape both the challenge handling and the test seams.
 
@@ -73,7 +73,7 @@ A challenge is treated as a **transient no-op** — clean exit, no alarm — *un
 
 **Dashboard** (`docs/index.html`): a single self-contained HTML/CSS/JS file using ECharts 5.4.3 from CDN, calling `fetch('data/combined_data.csv')`. That `fetch` is why it needs a real web server locally. No build step. Deployed by the `deploy-pages` job in `check-data.yml`, which re-deploys `docs/` from `main` after `check-data`.
 
-**GitHub Actions handoff**: `run_monitor.R` writes `data_updated` and `sample_date` to `$GITHUB_OUTPUT` via `set_gha_output()`. `check-data.yml` gates the commit/push, issue creation, and artifact upload on those values. `run_monitor.R` also emits `data_stale`/`stale_days` when MWRA has published nothing for over `MAX_STALE_DAYS`, which files one `stale-data` issue (guarded by an open-issue check, so it never repeats). Free-text outputs reach `github-script` through `env:`, never string interpolation.
+**GitHub Actions handoff**: `run_monitor.R` writes `data_updated` and `sample_date` to `$GITHUB_OUTPUT` via `set_gha_output()`. `check-data.yml` gates the commit/push, issue creation, and artifact upload on those values. It also emits `fetch_ok` on any clean page load, which triggers a state-only commit so `last_successful_fetch` persists across CI checkouts (see the bot-wall paragraph above). `run_monitor.R` also emits `data_stale`/`stale_days` when MWRA has published nothing for over `MAX_STALE_DAYS`, which files one `stale-data` issue (guarded by an open-issue check, so it never repeats). Free-text outputs reach `github-script` through `env:`, never string interpolation.
 
 ## The WastewaterSCAN pipeline
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -27,16 +27,43 @@ save_state <- function(state, state_file = "state/last_update.json") {
 
 #' Update state after successful download
 #'
+#' A successful download is by definition a clean fetch (we got the real page
+#' and PDF through the bot wall), so `last_successful_fetch` is advanced too.
+#'
 #' @param sample_date The sample collection date (character, YYYY-MM-DD format)
 #' @param pdf_url The relative PDF URL
 #' @return The updated state list
 update_state <- function(sample_date, pdf_url) {
+  now <- format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")
   state <- list(
     last_sample_date = sample_date,
     last_pdf_url = pdf_url,
-    last_check_time = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
-    last_download_time = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")
+    last_check_time = now,
+    last_download_time = now,
+    last_successful_fetch = now
   )
+  save_state(state)
+  state
+}
+
+#' Record that MWRA's page loaded cleanly (bypass is working)
+#'
+#' Advances `last_successful_fetch` (and `last_check_time`) whenever the update
+#' check gets the real page back rather than a bot-challenge interstitial --
+#' regardless of whether the data was new. This is what lets a bot challenge be
+#' tolerated as a transient no-op even while MWRA's publishing is paused: the
+#' hard-fail alarm keys off this marker, not off `last_sample_date`, so it fires
+#' only when the bypass genuinely can't get through for a long stretch.
+#'
+#' Persisting across CI runs depends on the workflow committing `state/` on
+#' clean runs, not only on data updates -- see check-data.yml.
+#'
+#' @return The updated state list
+record_successful_fetch <- function() {
+  now <- format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")
+  state <- load_state()
+  state$last_check_time <- now
+  state$last_successful_fetch <- now
   save_state(state)
   state
 }
@@ -50,11 +77,12 @@ log_check <- function() {
 
 #' Days since the most recent successfully processed sample date
 #'
-#' Used to decide whether a bot challenge can be tolerated as a transient
-#' no-op: `last_sample_date` only advances on successful data runs and (unlike
-#' any per-run counter) is committed to the repo, so it survives across fresh
-#' CI checkouts. If the newest data is old AND we're being challenged, the
-#' pipeline hasn't truly succeeded in a while and should fail loudly.
+#' Measures whether MWRA is still *publishing*: `last_sample_date` only advances
+#' when new data is processed and is committed to the repo, so it survives fresh
+#' CI checkouts. A large value means MWRA has paused (or the pipeline has been
+#' broken for a while) and drives the one-time `stale-data` issue. It is NOT the
+#' signal for tolerating a bot challenge -- that is `fetch_staleness_days()`,
+#' which tracks whether the bypass still works independently of publishing.
 #'
 #' @param state State list (defaults to the persisted state)
 #' @return Numeric days since last_sample_date, or NA if never recorded
@@ -63,6 +91,25 @@ data_staleness_days <- function(state = load_state()) {
     return(NA_real_)
   }
   as.numeric(Sys.Date() - as.Date(state$last_sample_date))
+}
+
+#' Days since MWRA's page last loaded cleanly (bypass last worked)
+#'
+#' Used to decide whether a bot challenge can be tolerated as a transient no-op.
+#' `last_successful_fetch` advances on every clean page load (via
+#' `record_successful_fetch()` / `update_state()`) whether or not the data was
+#' new, so it stays fresh even while MWRA's publishing is paused. Only when the
+#' bypass genuinely can't get through for a long stretch does this grow past the
+#' limit and turn a challenge into a hard failure. Like `last_sample_date`, it
+#' survives fresh CI checkouts only because the workflow commits it.
+#'
+#' @param state State list (defaults to the persisted state)
+#' @return Numeric days since last_successful_fetch, or NA if never recorded
+fetch_staleness_days <- function(state = load_state()) {
+  if (is.null(state$last_successful_fetch)) {
+    return(NA_real_)
+  }
+  as.numeric(Sys.Date() - as.Date(substr(state$last_successful_fetch, 1, 10)))
 }
 
 #' Retry wrapper for network operations

--- a/run_monitor.R
+++ b/run_monitor.R
@@ -32,32 +32,36 @@ if (force) message("FORCE MODE enabled")
 message("")
 
 # A transient Imperva bot challenge is tolerated as a clean no-op -- the next
-# run almost always recovers -- but if the newest processed data is already
-# this old, the pipeline hasn't truly succeeded in a long time (broken bypass
-# or MWRA stopped publishing) and the run should fail loudly instead.
+# run almost always recovers -- but if the bypass hasn't gotten a clean page
+# load through the bot wall in this long, it is genuinely broken (or the wall
+# changed) and the run should fail loudly instead. Note this is deliberately
+# NOT keyed off how old the *data* is: MWRA can pause publishing for weeks with
+# a perfectly healthy bypass, and that pause is reported separately via the
+# one-time stale-data issue below -- it must not turn every challenged run red.
 MAX_STALE_DAYS <- 14
 
-# Handle an all-retries-challenged fetch: no false alarm while the data is
-# reasonably fresh, hard failure once it goes stale. Called for both the
-# update check (Step 1) and the PDF download (Step 2). Note: no quit() here;
-# run_monitor.R is also source()d interactively.
+# Handle an all-retries-challenged fetch: no false alarm while the bypass is
+# still getting through on other runs, hard failure once it has been shut out
+# for MAX_STALE_DAYS. Called for both the update check (Step 1) and the PDF
+# download (Step 2). Note: no quit() here; run_monitor.R is also source()d
+# interactively.
 handle_challenge <- function(where) {
   message("")
   message("MWRA served a bot-challenge page during the ", where, ".")
   set_gha_output("data_updated", "false")
 
-  stale_days <- data_staleness_days()
+  stale_days <- fetch_staleness_days()
   if (!is.na(stale_days) && stale_days > MAX_STALE_DAYS) {
     stop(sprintf(paste0(
-      "Bot challenge encountered and the newest data is %.0f days old ",
-      "(limit %d). Either the curl-impersonate bypass no longer works or ",
-      "MWRA has stopped publishing -- needs a human look."),
+      "Bot challenge encountered and MWRA's page has not loaded cleanly in ",
+      "%.0f days (limit %d). The curl-impersonate bypass appears to be shut ",
+      "out -- needs a human look."),
       stale_days, MAX_STALE_DAYS))
   }
 
-  message("Newest data is ",
-          if (is.na(stale_days)) "of unknown age"
-          else sprintf("%.0f day(s) old", stale_days),
+  message("Bypass last got through ",
+          if (is.na(stale_days)) "at an unknown time"
+          else sprintf("%.0f day(s) ago", stale_days),
           "; treating this as transient. The next run should recover.")
 }
 
@@ -72,6 +76,12 @@ if (identical(update_info$status, "challenge")) {
   set_gha_output("data_updated", "false")
   stop("Check failed")
 } else {
+
+  # The page loaded cleanly (real content, not a challenge), so the bypass is
+  # working right now. Record it -- committed on clean runs by the workflow --
+  # so a later challenged run keeps quiet instead of tripping the hard-fail.
+  record_successful_fetch()
+  set_gha_output("fetch_ok", "true")
 
   message("  Current sample date: ", update_info$sample_date)
   message("  Previous sample date: ",

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -85,6 +85,7 @@ describe("update_state()", {
     expect_equal(result$last_pdf_url, "/biobot/test.pdf")
     expect_true(!is.null(result$last_check_time))
     expect_true(!is.null(result$last_download_time))
+    expect_true(!is.null(result$last_successful_fetch))
   })
 
   it("formats timestamps in ISO 8601 UTC format", {
@@ -215,6 +216,64 @@ describe("data_staleness_days()", {
   it("returns NA when no sample date is recorded", {
     expect_true(is.na(data_staleness_days(list())))
     expect_true(is.na(data_staleness_days(list(last_pdf_url = "/x"))))
+  })
+})
+
+describe("fetch_staleness_days()", {
+  it("returns days since last_successful_fetch", {
+    five_days_ago <- format(Sys.Date() - 5, "%Y-%m-%dT%H:%M:%SZ")
+    expect_equal(
+      fetch_staleness_days(list(last_successful_fetch = five_days_ago)),
+      5
+    )
+  })
+
+  it("parses a timestamp with a time component", {
+    ts <- paste0(format(Sys.Date() - 3, "%Y-%m-%d"), "T22:44:14Z")
+    expect_equal(fetch_staleness_days(list(last_successful_fetch = ts)), 3)
+  })
+
+  it("returns NA when no successful fetch is recorded", {
+    expect_true(is.na(fetch_staleness_days(list())))
+    expect_true(is.na(fetch_staleness_days(list(last_sample_date = "2024-01-01"))))
+  })
+})
+
+describe("record_successful_fetch()", {
+  it("advances last_successful_fetch without touching last_sample_date", {
+    temp_dir <- withr::local_tempdir()
+    state_file <- file.path(temp_dir, "state.json")
+
+    initial_state <- list(
+      last_sample_date = "2024-12-20",
+      last_pdf_url = "/biobot/old.pdf",
+      last_check_time = "2024-12-20T10:00:00Z",
+      last_successful_fetch = "2024-12-20T10:00:00Z"
+    )
+    jsonlite::write_json(initial_state, state_file, auto_unbox = TRUE)
+
+    original_load_state <- load_state
+    original_save_state <- save_state
+    assign("load_state", function(sf = "state/last_update.json") {
+      jsonlite::read_json(state_file)
+    }, envir = .GlobalEnv)
+    assign("save_state", function(state, sf = "state/last_update.json") {
+      jsonlite::write_json(state, state_file, auto_unbox = TRUE, pretty = TRUE)
+    }, envir = .GlobalEnv)
+    on.exit({
+      assign("load_state", original_load_state, envir = .GlobalEnv)
+      assign("save_state", original_save_state, envir = .GlobalEnv)
+    }, add = TRUE)
+
+    record_successful_fetch()
+
+    updated <- jsonlite::read_json(state_file)
+    # Publishing date is untouched; the fetch and check markers advance.
+    expect_equal(updated$last_sample_date, "2024-12-20")
+    expect_true(updated$last_successful_fetch != "2024-12-20T10:00:00Z")
+    expect_true(updated$last_check_time != "2024-12-20T10:00:00Z")
+    expect_match(updated$last_successful_fetch,
+                 "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$")
   })
 })
 


### PR DESCRIPTION
## Problem

The **Check MWRA Biobot Data** workflow was failing intermittently — roughly half of scheduled runs went red (e.g. 08-09 22:10 failed in 4m43s; 08-09 14:19 succeeded). Confirmed from the failed run log:

> `Bot challenge encountered and the newest data is 20 days old (limit 14).`

This is `handle_challenge()`'s own "wake a human" alarm firing as designed, but for a benign reason. Two independent things are true right now:

1. **MWRA stopped publishing on July 20** → newest sample is >14 days old (`MAX_STALE_DAYS`).
2. **MWRA's Imperva bot wall intermittently serves a challenge page.**

The alarm hard-fails only when *both* hold — so runs that get a clean page load succeed (and file the single `stale-data` issue), while runs that hit the challenge fail red. The scraper is healthy; the pause is already surfaced by the `stale-data` issue, so the red X's are pure noise. (The "~5 min" run duration is `with_retry()`'s 4 backed-off retries, not the schedule.)

The root cause: *"is MWRA publishing?"* and *"does our bypass still work?"* were both measured against `last_sample_date`.

## Fix

Decouple the two conditions:

- **`R/utils.R`** — add `last_successful_fetch` (advanced on any clean page load, new data or not) via the new `record_successful_fetch()` and in `update_state()`; add `fetch_staleness_days()` mirroring `data_staleness_days()`.
- **`run_monitor.R`** — `handle_challenge()` now keys its hard-fail off `fetch_staleness_days()`, so a bot challenge is a quiet no-op while the bypass is getting through on other runs, and only fails loudly once the bypass is genuinely shut out for `MAX_STALE_DAYS`. The `stale-data` issue (via `data_staleness_days()` / `last_sample_date`) remains the sole signal for MWRA's publishing pause.
- **`.github/workflows/check-data.yml`** — commit `state/` on clean no-new-data runs (gated on a new `fetch_ok` output), so `last_successful_fetch` survives fresh CI checkouts; without this it would reset to stale every run and defeat the fix (same reason `last_check_time` was frozen at 2026-07-24). Schedule cut from twice daily to **once daily** (`48 13 * * *`).
- **Tests** — add `fetch_staleness_days()` and `record_successful_fetch()` coverage in `test-utils.R`, plus a `last_successful_fetch` assertion on `update_state()`.
- **`CLAUDE.md`** — document the three-way distinction: *challenged but bypass healthy → retry* / *MWRA paused → one issue* / *bypass genuinely shut out → wake a human*.

## Net effect

- No more red X's caused by MWRA's publishing pause; the `stale-data` issue still reports the pause, and the normal update notification fires when MWRA resumes.
- The genuine alarm is preserved: a truly broken bypass (challenged on every run for 14 days) still fails loudly.

## Testing

R is not installed in the dev environment (the pipeline runs inside the prebuilt GHCR image), so the suite was **not run locally** — changes were reviewed by hand and the workflow YAML validated. `run_tests.R` runs in CI; the 2 known-stale `test-visualize.R` palette failures are pre-existing and unrelated. After merge, trigger the workflow via **Run workflow** to confirm it goes green and commits `last_successful_fetch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T1Xgo35oJ64JvyPvPYftF8)_